### PR TITLE
Fix display of logs in notebook

### DIFF
--- a/AGIPMAgent_Colab_TrelloSimule.ipynb
+++ b/AGIPMAgent_Colab_TrelloSimule.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pd.DataFrame(logs)\n"
+    "print(pd.DataFrame(logs))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- ensure the log dataframe prints at the end of the notebook

## Testing
- `python <(jq -r '.cells[].source | join("")' AGIPMAgent_Colab_TrelloSimule.ipynb)`

------
https://chatgpt.com/codex/tasks/task_e_685979fcea24832dbec607a2a4ea87e7